### PR TITLE
feat: Create an installable WordPress plugin for the Idealista scraper

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# A simple script to build the WordPress plugin zip file.
+
+# Set the plugin slug and version.
+PLUGIN_SLUG="wp-idealista-scraper"
+PLUGIN_VERSION=$(grep -i "Version:" "wp-idealista-scraper/wp-idealista-scraper.php" | awk -F' ' '{print $2}' | tr -d '\r')
+
+# Set the build directory.
+BUILD_DIR="build"
+
+# Create the build directory if it doesn't exist.
+mkdir -p $BUILD_DIR
+
+# Set the zip file name.
+ZIP_FILE="$BUILD_DIR/$PLUGIN_SLUG.$PLUGIN_VERSION.zip"
+
+# Create the zip file.
+echo "Creating zip file: $ZIP_FILE"
+zip -r $ZIP_FILE $PLUGIN_SLUG -x "*.git*" "*build.sh*" "*README.md*" "*docs/*"
+
+echo "Build complete."

--- a/wp-idealista-scraper/README.md
+++ b/wp-idealista-scraper/README.md
@@ -1,0 +1,81 @@
+# Idealista Scraper WordPress Plugin
+
+This WordPress plugin provides a user interface for the Idealista Scraper backend. It allows you to start and stop scraping sessions, monitor their status, and view the scraped data from within your WordPress admin dashboard.
+
+## Requirements
+
+*   A running instance of the Idealista Scraper backend.
+*   WordPress version 5.0 or higher.
+*   PHP version 7.2 or higher.
+
+## Installation
+
+### Backend Setup
+
+1.  **Clone the repository:**
+    ```bash
+    git clone <repository_url>
+    cd <repository_directory>
+    ```
+
+2.  **Install Python dependencies:**
+    Navigate to the `backend` directory and install the required Python packages using pip.
+    ```bash
+    cd backend
+    pip install -r requirements.txt
+    ```
+
+3.  **Configure the environment:**
+    Create a `.env` file in the `backend` directory by copying the `.env.example` file.
+    ```bash
+    cp .env.example .env
+    ```
+    Edit the `.env` file and provide the necessary configuration, such as your MongoDB connection string.
+
+4.  **Run the backend server:**
+    From the `backend` directory, run the following command to start the FastAPI server:
+    ```bash
+    uvicorn server:app --host 0.0.0.0 --port 8000
+    ```
+    The server will be running at `http://<your_server_ip>:8000`.
+
+### Plugin Setup
+
+1.  **Build the plugin zip file:**
+    From the root of the project directory, run the `build.sh` script to create a distributable zip file of the plugin.
+    ```bash
+    ./build.sh
+    ```
+    This will create a file named `wp-idealista-scraper.<version>.zip` in the `build` directory.
+
+2.  **Install the plugin in WordPress:**
+    -   Log in to your WordPress admin dashboard.
+    -   Navigate to **Plugins > Add New**.
+    -   Click the **Upload Plugin** button.
+    -   Choose the `wp-idealista-scraper.<version>.zip` file you created and click **Install Now**.
+    -   Activate the plugin.
+
+3.  **Configure the plugin:**
+    -   Navigate to the **Idealista Scraper** menu in your WordPress admin dashboard.
+    -   In the **API Settings** section, enter the URL of your running backend server (e.g., `http://<your_server_ip>:8000`).
+    -   Click **Save Changes**.
+
+## Usage
+
+Once the plugin is installed and configured, you can use the Idealista Scraper dashboard to:
+
+*   **Start a new scraping session:** Click the "Start New Scraping Session" button to begin scraping.
+*   **Monitor session status:** The dashboard will automatically update to show the status of all scraping sessions.
+*   **Solve CAPTCHAs:** If a session requires a CAPTCHA to be solved, a CAPTCHA image and input field will appear. Enter the solution to continue scraping.
+*   **View scraped data:** The "Scraped Data" section will display the properties that have been scraped from Idealista.
+
+## Development
+
+The plugin is structured using a boilerplate that separates the admin-facing functionality, internationalization, and the core plugin logic.
+
+*   `wp-idealista-scraper.php`: The main plugin file.
+*   `includes/`: Contains the core plugin classes.
+*   `admin/`: Contains the admin-facing functionality.
+*   `assets/`: Contains the CSS and JavaScript for the plugin.
+
+To contribute to the development, you can edit the files directly and then run the `build.sh` script to create a new zip file.

--- a/wp-idealista-scraper/admin/class-idealista-scraper-admin.php
+++ b/wp-idealista-scraper/admin/class-idealista-scraper-admin.php
@@ -1,0 +1,272 @@
+<?php
+
+/**
+ * The admin-specific functionality of the plugin.
+ *
+ * @link       https://example.com/
+ * @since      1.0.0
+ *
+ * @package    Idealista_Scraper
+ * @subpackage Idealista_Scraper/admin
+ */
+
+/**
+ * The admin-specific functionality of the plugin.
+ *
+ * Defines the plugin name, version, and two examples hooks for how to
+ * enqueue the admin-specific stylesheet and JavaScript.
+ *
+ * @package    Idealista_Scraper
+ * @subpackage Idealista_Scraper/admin
+ * @author     Jules <jules@example.com>
+ */
+class Idealista_Scraper_Admin {
+
+    /**
+     * The ID of this plugin.
+     *
+     * @since    1.0.0
+     * @access   private
+     * @var      string    $plugin_name    The ID of this plugin.
+     */
+    private $plugin_name;
+
+    /**
+     * The version of this plugin.
+     *
+     * @since    1.0.0
+     * @access   private
+     * @var      string    $version    The current version of this plugin.
+     */
+    private $version;
+
+    /**
+     * Initialize the class and set its properties.
+     *
+     * @since    1.0.0
+     * @param      string    $plugin_name       The name of this plugin.
+     * @param      string    $version    The version of this plugin.
+     */
+    public function __construct( $plugin_name, $version ) {
+
+        $this->plugin_name = $plugin_name;
+        $this->version = $version;
+
+    }
+
+    /**
+     * Register the stylesheets for the admin area.
+     *
+     * @since    1.0.0
+     */
+    public function enqueue_styles() {
+
+        wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/idealista-scraper-admin.css', array(), $this->version, 'all' );
+
+    }
+
+    /**
+     * Register the JavaScript for the admin area.
+     *
+     * @since    1.0.0
+     */
+    public function enqueue_scripts() {
+
+        wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/idealista-scraper-admin.js', array( 'jquery' ), $this->version, false );
+
+        // Pass ajax url and nonces to the script
+        wp_localize_script( $this->plugin_name, 'idealista_scraper_ajax', array(
+            'ajax_url' => admin_url( 'admin-ajax.php' ),
+            'api_url' => get_option('idealista_scraper_api_url'),
+            'start_scraping_nonce' => wp_create_nonce('idealista_scraper_start_scraping'),
+            'solve_captcha_nonce' => wp_create_nonce('idealista_scraper_solve_captcha'),
+        ) );
+    }
+
+    /**
+     * Add the admin menu for the plugin.
+     *
+     * @since    1.0.0
+     */
+    public function add_plugin_admin_menu() {
+        add_menu_page(
+            'Idealista Scraper',
+            'Idealista Scraper',
+            'manage_options',
+            $this->plugin_name,
+            array( $this, 'display_plugin_setup_page' ),
+            'dashicons-admin-generic',
+            25
+        );
+    }
+
+    /**
+     * Display the admin page.
+     *
+     * @since    1.0.0
+     */
+    public function display_plugin_setup_page() {
+        require_once 'partials/idealista-scraper-admin-display.php';
+    }
+
+    /**
+     * Register the settings for the plugin.
+     *
+     * @since    1.0.0
+     */
+    public function register_settings() {
+        register_setting(
+            'idealista_scraper_options',
+            'idealista_scraper_api_url',
+            array(
+                'type' => 'string',
+                'sanitize_callback' => 'esc_url_raw',
+            )
+        );
+
+        add_settings_section(
+            'idealista_scraper_api_settings_section',
+            'API Settings',
+            array( $this, 'api_settings_section_callback' ),
+            'idealista-scraper-options'
+        );
+
+        add_settings_field(
+            'idealista_scraper_api_url_field',
+            'API URL',
+            array( $this, 'api_url_field_callback' ),
+            'idealista-scraper-options',
+            'idealista_scraper_api_settings_section'
+        );
+    }
+
+    /**
+     * Callback for the API settings section.
+     *
+     * @since    1.0.0
+     */
+    public function api_settings_section_callback() {
+        echo '<p>Enter the URL of the Idealista Scraper API.</p>';
+    }
+
+    /**
+     * Callback for the API URL field.
+     *
+     * @since    1.0.0
+     */
+    public function api_url_field_callback() {
+        $api_url = get_option('idealista_scraper_api_url');
+        echo '<input type="text" id="idealista_scraper_api_url" name="idealista_scraper_api_url" value="' . esc_attr($api_url) . '" class="regular-text" />';
+    }
+
+    /**
+     * Start the scraping process.
+     *
+     * @since    1.0.0
+     */
+    public function start_scraping() {
+        // Security check
+        check_ajax_referer('idealista_scraper_start_scraping', 'security');
+
+        $api_url = get_option('idealista_scraper_api_url');
+        if (empty($api_url)) {
+            wp_send_json_error('API URL is not configured.');
+        }
+
+        $response = wp_remote_post($api_url . '/api/scrape/start', array(
+            'method'    => 'POST',
+            'timeout'   => 45,
+            'blocking'  => true,
+        ));
+
+        if (is_wp_error($response)) {
+            wp_send_json_error($response->get_error_message());
+        }
+
+        $body = wp_remote_retrieve_body($response);
+        $data = json_decode($body, true);
+
+        wp_send_json_success($data);
+    }
+
+    /**
+     * Get the scraped data.
+     *
+     * @since    1.0.0
+     */
+    public function get_scraped_data() {
+        $api_url = get_option('idealista_scraper_api_url');
+        if (empty($api_url)) {
+            wp_send_json_error('API URL is not configured.');
+        }
+
+        $response = wp_remote_get($api_url . '/api/properties');
+
+        if (is_wp_error($response)) {
+            wp_send_json_error($response->get_error_message());
+        }
+
+        $body = wp_remote_retrieve_body($response);
+        $data = json_decode($body, true);
+
+        wp_send_json_success($data);
+    }
+
+    /**
+     * Get the scraping status.
+     *
+     * @since    1.0.0
+     */
+    public function get_scraping_status() {
+        $api_url = get_option('idealista_scraper_api_url');
+        if (empty($api_url)) {
+            wp_send_json_error('API URL is not configured.');
+        }
+
+        $response = wp_remote_get($api_url . '/api/scraping-sessions');
+
+        if (is_wp_error($response)) {
+            wp_send_json_error($response->get_error_message());
+        }
+
+        $body = wp_remote_retrieve_body($response);
+        $data = json_decode($body, true);
+
+        wp_send_json_success($data);
+    }
+
+    /**
+     * Solve the captcha.
+     *
+     * @since    1.0.0
+     */
+    public function solve_captcha() {
+        // Security check
+        check_ajax_referer('idealista_scraper_solve_captcha', 'security');
+
+        $api_url = get_option('idealista_scraper_api_url');
+        if (empty($api_url)) {
+            wp_send_json_error('API URL is not configured.');
+        }
+
+        $session_id = sanitize_text_field($_POST['session_id']);
+        $solution = sanitize_text_field($_POST['solution']);
+
+        $response = wp_remote_post($api_url . '/api/captcha/' . $session_id . '/solve', array(
+            'method'    => 'POST',
+            'timeout'   => 45,
+            'blocking'  => true,
+            'body'      => json_encode(array('solution' => $solution)),
+            'headers'   => array('Content-Type' => 'application/json')
+        ));
+
+        if (is_wp_error($response)) {
+            wp_send_json_error($response->get_error_message());
+        }
+
+        $body = wp_remote_retrieve_body($response);
+        $data = json_decode($body, true);
+
+        wp_send_json_success($data);
+    }
+}

--- a/wp-idealista-scraper/admin/css/idealista-scraper-admin.css
+++ b/wp-idealista-scraper/admin/css/idealista-scraper-admin.css
@@ -1,0 +1,62 @@
+/**
+ * All of the CSS for your admin-specific functionality should be
+ * included in this file.
+ */
+
+#scraper-dashboard, #captcha-solver, #scraped-data {
+    margin-top: 20px;
+    padding: 15px;
+    border: 1px solid #ccd0d4;
+    background-color: #fff;
+    box-shadow: 0 1px 1px rgba(0,0,0,.04);
+}
+
+#scraping-status, #scraped-data-container {
+    margin-top: 15px;
+    padding: 10px;
+    border: 1px solid #e5e5e5;
+    max-height: 400px;
+    overflow-y: auto;
+}
+
+#captcha-image {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    border: 1px solid #ccc;
+}
+
+#captcha-solution {
+    margin-right: 10px;
+}
+
+.session-running {
+    color: #ffb900;
+}
+
+.session-completed {
+    color: #46b450;
+}
+
+.session-failed {
+    color: #dc3232;
+}
+
+.session-waiting_captcha {
+    color: #f56e28;
+}
+
+table.scraped-data-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+table.scraped-data-table th,
+table.scraped-data-table td {
+    padding: 8px;
+    border: 1px solid #ddd;
+    text-align: left;
+}
+
+table.scraped-data-table th {
+    background-color: #f2f2f2;
+}

--- a/wp-idealista-scraper/admin/js/idealista-scraper-admin.js
+++ b/wp-idealista-scraper/admin/js/idealista-scraper-admin.js
@@ -1,0 +1,136 @@
+(function( $ ) {
+    'use strict';
+
+    $(function() {
+        // Start scraping button
+        $('#start-scraping').on('click', function() {
+            var $button = $(this);
+            $button.prop('disabled', true).text('Starting...');
+
+            $.post(idealista_scraper_ajax.ajax_url, {
+                action: 'start_scraping',
+                security: idealista_scraper_ajax.start_scraping_nonce
+            }, function(response) {
+                if (response.success) {
+                    alert('Scraping session started successfully. Session ID: ' + response.data.session_id);
+                    updateScrapingStatus();
+                } else {
+                    alert('Error: ' + response.data);
+                }
+                $button.prop('disabled', false).text('Start New Scraping Session');
+            });
+        });
+
+        // Submit CAPTCHA button
+        $('#submit-captcha').on('click', function() {
+            var $button = $(this);
+            var solution = $('#captcha-solution').val();
+            var sessionId = $('#captcha-session-id').val();
+
+            if (!solution) {
+                alert('Please enter the CAPTCHA solution.');
+                return;
+            }
+
+            $button.prop('disabled', true).text('Submitting...');
+
+            $.post(idealista_scraper_ajax.ajax_url, {
+                action: 'solve_captcha',
+                security: idealista_scraper_ajax.solve_captcha_nonce,
+                session_id: sessionId,
+                solution: solution
+            }, function(response) {
+                if (response.success && response.data.success) {
+                    alert('CAPTCHA solved successfully. Scraping will resume.');
+                    $('#captcha-solver').hide();
+                    updateScrapingStatus();
+                } else {
+                    alert('Error: ' + (response.data.message || response.data));
+                }
+                $button.prop('disabled', false).text('Submit Solution');
+            });
+        });
+
+        // Function to update scraping status
+        function updateScrapingStatus() {
+            var $statusContainer = $('#scraping-status');
+            $statusContainer.html('Loading status...');
+
+            $.get(idealista_scraper_ajax.ajax_url, {
+                action: 'get_scraping_status'
+            }, function(response) {
+                if (response.success) {
+                    var sessions = response.data;
+                    var html = '<ul>';
+                    var showCaptcha = false;
+
+                    sessions.forEach(function(session) {
+                        html += '<li>';
+                        html += '<strong>Session ID:</strong> ' + session.id + ' - ';
+                        html += '<strong class="session-' + session.status + '">Status:</strong> ' + session.status;
+                        if (session.status === 'waiting_captcha') {
+                            showCaptcha = true;
+                            $('#captcha-session-id').val(session.id);
+                            $('#captcha-image').attr('src', idealista_scraper_ajax.api_url + '/api/captcha/' + session.id);
+                        }
+                        html += '</li>';
+                    });
+
+                    html += '</ul>';
+                    $statusContainer.html(html);
+
+                    if (showCaptcha) {
+                        $('#captcha-solver').show();
+                    } else {
+                        $('#captcha-solver').hide();
+                    }
+
+                    // Also update the scraped data
+                    updateScrapedData();
+
+                } else {
+                    $statusContainer.html('Error loading status.');
+                }
+            });
+        }
+
+        // Function to update scraped data
+        function updateScrapedData() {
+            var $dataContainer = $('#scraped-data-container');
+            $dataContainer.html('Loading data...');
+
+             $.get(idealista_scraper_ajax.ajax_url, {
+                action: 'get_scraped_data'
+            }, function(response) {
+                 if (response.success) {
+                    var properties = response.data;
+                    var html = '<table class="scraped-data-table"><thead><tr><th>Region</th><th>Location</th><th>Type</th><th>Operation</th><th>Price/sqm</th><th>URL</th></tr></thead><tbody>';
+
+                    properties.forEach(function(prop) {
+                        html += '<tr>';
+                        html += '<td>' + prop.region + '</td>';
+                        html += '<td>' + prop.location + '</td>';
+                        html += '<td>' + prop.property_type + '</td>';
+                        html += '<td>' + prop.operation_type + '</td>';
+                        html += '<td>' + (prop.price_per_sqm ? prop.price_per_sqm.toFixed(2) + ' €' : 'N/A') + '</td>';
+                        html += '<td><a href="' + prop.url + '" target="_blank">Link</a></td>';
+                        html += '</tr>';
+                    });
+
+                    html += '</tbody></table>';
+                    $dataContainer.html(html);
+                } else {
+                    $dataContainer.html('Error loading data.');
+                }
+            });
+        }
+
+
+        // Initial status update
+        updateScrapingStatus();
+
+        // Periodically update status
+        setInterval(updateScrapingStatus, 15000); // every 15 seconds
+    });
+
+})( jQuery );

--- a/wp-idealista-scraper/admin/partials/idealista-scraper-admin-display.php
+++ b/wp-idealista-scraper/admin/partials/idealista-scraper-admin-display.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Provide a admin area view for the plugin
+ *
+ * This file is used to markup the admin-facing aspects of the plugin.
+ *
+ * @link       https://example.com/
+ * @since      1.0.0
+ *
+ * @package    Idealista_Scraper
+ * @subpackage Idealista_Scraper/admin/partials
+ */
+?>
+
+<div class="wrap">
+    <h1><?php echo esc_html(get_admin_page_title()); ?></h1>
+
+    <form method="post" action="options.php">
+        <?php
+        settings_fields('idealista_scraper_options');
+        do_settings_sections('idealista-scraper-options');
+        submit_button();
+        ?>
+    </form>
+
+    <div id="scraper-dashboard">
+        <h2>Scraper Dashboard</h2>
+        <button id="start-scraping" class="button button-primary">Start New Scraping Session</button>
+        <div id="scraping-status"></div>
+    </div>
+
+    <div id="captcha-solver" style="display:none;">
+        <h2>CAPTCHA Required</h2>
+        <p>A CAPTCHA is required to continue scraping. Please solve the CAPTCHA below.</p>
+        <img id="captcha-image" src="" alt="CAPTCHA Image" />
+        <input type="text" id="captcha-solution" placeholder="Enter CAPTCHA solution" />
+        <button id="submit-captcha" class.php="button button-primary">Submit Solution</button>
+        <input type="hidden" id="captcha-session-id" value="" />
+    </div>
+
+    <div id="scraped-data">
+        <h2>Scraped Data</h2>
+        <div id="scraped-data-container"></div>
+    </div>
+</div>

--- a/wp-idealista-scraper/includes/class-idealista-scraper-i18n.php
+++ b/wp-idealista-scraper/includes/class-idealista-scraper-i18n.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Define the internationalization functionality
+ *
+ * Loads and defines the internationalization files for this plugin
+ * so that it is ready for translation.
+ *
+ * @link       https://example.com/
+ * @since      1.0.0
+ *
+ * @package    Idealista_Scraper
+ * @subpackage Idealista_Scraper/includes
+ */
+
+/**
+ * Define the internationalization functionality.
+ *
+ * Loads and defines the internationalization files for this plugin
+ * so that it is ready for translation.
+ *
+ * @since      1.0.0
+ * @package    Idealista_Scraper
+ * @subpackage Idealista_Scraper/includes
+ * @author     Jules <jules@example.com>
+ */
+class Idealista_Scraper_i18n {
+
+
+    /**
+     * Load the plugin text domain for translation.
+     *
+     * @since    1.0.0
+     */
+    public function load_plugin_textdomain() {
+
+        load_plugin_textdomain(
+            'idealista-scraper',
+            false,
+            dirname( dirname( plugin_basename( __FILE__ ) ) ) . '/languages/'
+        );
+
+    }
+
+
+
+}

--- a/wp-idealista-scraper/includes/class-idealista-scraper-loader.php
+++ b/wp-idealista-scraper/includes/class-idealista-scraper-loader.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Register all actions and filters for the plugin
+ *
+ * @link       https://example.com/
+ * @since      1.0.0
+ *
+ * @package    Idealista_Scraper
+ * @subpackage Idealista_Scraper/includes
+ */
+
+/**
+ * Register all actions and filters for the plugin.
+ *
+ * Maintain a list of all hooks that are registered throughout
+ * the plugin, and register them with the WordPress API. Call the
+ * run function to execute the list of actions and filters.
+ *
+ * @package    Idealista_Scraper
+ * @subpackage Idealista_Scraper/includes
+ * @author     Jules <jules@example.com>
+ */
+class Idealista_Scraper_Loader {
+
+    /**
+     * The array of actions registered with WordPress.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      array    $actions    The actions registered with WordPress to fire when the plugin loads.
+     */
+    protected $actions;
+
+    /**
+     * The array of filters registered with WordPress.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      array    $filters    The filters registered with WordPress to fire when the plugin loads.
+     */
+    protected $filters;
+
+    /**
+     * Initialize the collections used to maintain the actions and filters.
+     *
+     * @since    1.0.0
+     */
+    public function __construct() {
+
+        $this->actions = array();
+        $this->filters = array();
+
+    }
+
+    /**
+     * Add a new action to the collection to be registered with WordPress.
+     *
+     * @since    1.0.0
+     * @param    string               $hook             The name of the WordPress action that is being registered.
+     * @param    object               $component        A reference to the instance of the object on which the action is defined.
+     * @param    string               $callback         The name of the function definition on the $component.
+     * @param    int                  $priority         Optional. The priority at which the function should be fired. Default is 10.
+     * @param    int                  $accepted_args    Optional. The number of arguments that should be passed to the $callback. Default is 1.
+     */
+    public function add_action( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
+        $this->actions = $this->add( $this->actions, $hook, $component, $callback, $priority, $accepted_args );
+    }
+
+    /**
+     * Add a new filter to the collection to be registered with WordPress.
+     *
+     * @since    1.0.0
+     * @param    string               $hook             The name of the WordPress filter that is being registered.
+     * @param    object               $component        A reference to the instance of the object on which the filter is defined.
+     * @param    string               $callback         The name of the function definition on the $component.
+     * @param    int                  $priority         Optional. The priority at which the function should be fired. Default is 10.
+     * @param    int                  $accepted_args    Optional. The number of arguments that should be passed to the $callback. Default is 1.
+     */
+    public function add_filter( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
+        $this->filters = $this->add( $this->filters, $hook, $component, $callback, $priority, $accepted_args );
+    }
+
+    /**
+     * A utility function that is used to register the actions and hooks into a single
+     * collection.
+     *
+     * @since    1.0.0
+     * @access   private
+     * @param    array                $hooks            The collection of hooks that is being registered (that is, actions or filters).
+     * @param    string               $hook             The name of the WordPress filter that is being registered.
+     * @param    object               $component        A reference to the instance of the object on which the filter is defined.
+     * @param    string               $callback         The name of the function definition on the $component.
+     * @param    int                  $priority         The priority at which the function should be fired.
+     * @param    int                  $accepted_args    The number of arguments that should be passed to the $callback.
+     * @return   array                                  The collection of actions and filters registered with WordPress.
+     */
+    private function add( $hooks, $hook, $component, $callback, $priority, $accepted_args ) {
+
+        $hooks[] = array(
+            'hook'          => $hook,
+            'component'     => $component,
+            'callback'      => $callback,
+            'priority'      => $priority,
+            'accepted_args' => $accepted_args
+        );
+
+        return $hooks;
+
+    }
+
+    /**
+     * Register the filters and actions with WordPress.
+     *
+     * @since    1.0.0
+     */
+    public function run() {
+
+        foreach ( $this->filters as $hook ) {
+            add_filter( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+        }
+
+        foreach ( $this->actions as $hook ) {
+            add_action( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+        }
+
+    }
+
+}

--- a/wp-idealista-scraper/includes/class-idealista-scraper.php
+++ b/wp-idealista-scraper/includes/class-idealista-scraper.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * The file that defines the core plugin class
+ *
+ * A class definition that includes attributes and functions used across both the
+ * public-facing side of the site and the admin area.
+ *
+ * @link       https://example.com/
+ * @since      1.0.0
+ *
+ * @package    Idealista_Scraper
+ * @subpackage Idealista_Scraper/includes
+ */
+
+/**
+ * The core plugin class.
+ *
+ * This is used to define internationalization, admin-specific hooks, and
+ * public-facing site hooks.
+ *
+ * Also maintains the unique identifier of this plugin as well as the current
+ * version of the plugin.
+ *
+ * @since      1.0.0
+ * @package    Idealista_Scraper
+ * @subpackage Idealista_Scraper/includes
+ * @author     Jules <jules@example.com>
+ */
+class Idealista_Scraper {
+
+    /**
+     * The loader that's responsible for maintaining and registering all hooks that power
+     * the plugin.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      Idealista_Scraper_Loader    $loader    Maintains and registers all hooks for the plugin.
+     */
+    protected $loader;
+
+    /**
+     * The unique identifier of this plugin.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      string    $plugin_name    The string used to uniquely identify this plugin.
+     */
+    protected $plugin_name;
+
+    /**
+     * The current version of the plugin.
+     *
+     * @since    1.0.0
+     * @access   protected
+     * @var      string    $version    The current version of the plugin.
+     */
+    protected $version;
+
+    /**
+     * Define the core functionality of the plugin.
+     *
+     * Set the plugin name and the plugin version that can be used throughout the plugin.
+     * Load the dependencies, define the locale, and set the hooks for the admin area and
+     * the public-facing side of the site.
+     *
+     * @since    1.0.0
+     */
+    public function __construct() {
+
+        $this->plugin_name = 'idealista-scraper';
+        $this->version = '1.0.0';
+
+        $this->load_dependencies();
+        $this->set_locale();
+        $this->define_admin_hooks();
+
+    }
+
+    /**
+     * Load the required dependencies for this plugin.
+     *
+     * Include the following files that make up the plugin:
+     *
+     * - Idealista_Scraper_Loader. Orchestrates the hooks of the plugin.
+     * - Idealista_Scraper_i18n. Defines internationalization functionality.
+     * - Idealista_Scraper_Admin. Defines all hooks for the admin area.
+     *
+     * @since    1.0.0
+     * @access   private
+     */
+    private function load_dependencies() {
+
+        /**
+         * The class responsible for orchestrating the actions and filters of the
+         * core plugin.
+         */
+        require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-idealista-scraper-loader.php';
+
+        /**
+         * The class responsible for defining internationalization functionality
+         * of the plugin.
+         */
+        require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-idealista-scraper-i18n.php';
+
+        /**
+         * The class responsible for defining all actions that occur in the admin area.
+         */
+        require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-idealista-scraper-admin.php';
+
+        $this->loader = new Idealista_Scraper_Loader();
+
+    }
+
+    /**
+     * Define the locale for this plugin for internationalization.
+     *
+     * Uses the Idealista_Scraper_i18n class in order to set the domain and to register the hook
+     * with WordPress.
+     *
+     * @since    1.0.0
+     * @access   private
+     */
+    private function set_locale() {
+
+        $plugin_i18n = new Idealista_Scraper_i18n();
+
+        $this->loader->add_action( 'plugins_loaded', $plugin_i18n, 'load_plugin_textdomain' );
+
+    }
+
+    /**
+     * Register all of the hooks related to the admin area functionality
+     * of the plugin.
+     *
+     * @since    1.0.0
+     * @access   private
+     */
+    private function define_admin_hooks() {
+
+        $plugin_admin = new Idealista_Scraper_Admin( $this->get_plugin_name(), $this->get_version() );
+
+        $this->loader->add_action( 'admin_menu', $plugin_admin, 'add_plugin_admin_menu' );
+        $this->loader->add_action( 'admin_init', $plugin_admin, 'register_settings' );
+        $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
+        $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
+
+        // Add AJAX action for starting the scraper
+        $this->loader->add_action( 'wp_ajax_start_scraping', $plugin_admin, 'start_scraping' );
+        $this->loader->add_action( 'wp_ajax_get_scraping_status', $plugin_admin, 'get_scraping_status' );
+        $this->loader->add_action( 'wp_ajax_solve_captcha', $plugin_admin, 'solve_captcha' );
+        $this->loader->add_action( 'wp_ajax_get_scraped_data', $plugin_admin, 'get_scraped_data' );
+
+
+    }
+
+    /**
+     * Run the loader to execute all of the hooks with WordPress.
+     *
+     * @since    1.0.0
+     */
+    public function run() {
+        $this->loader->run();
+    }
+
+    /**
+     * The name of the plugin used to uniquely identify it within the context of
+     * WordPress and to define internationalization functionality.
+     *
+     * @since     1.0.0
+     * @return    string    The name of the plugin.
+     */
+    public function get_plugin_name() {
+        return $this->plugin_name;
+    }
+
+    /**
+     * The reference to the class that orchestrates the hooks with the plugin.
+     *
+     * @since     1.0.0
+     * @return    Idealista_Scraper_Loader    Orchestrates the hooks of the plugin.
+     */
+    public function get_loader() {
+        return $this->loader;
+    }
+
+    /**
+     * Retrieve the version number of the plugin.
+     *
+     * @since     1.0.0
+     * @return    string    The version number of the plugin.
+     */
+    public function get_version() {
+        return $this->version;
+    }
+
+}

--- a/wp-idealista-scraper/wp-idealista-scraper.php
+++ b/wp-idealista-scraper/wp-idealista-scraper.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Plugin Name:     Idealista Scraper
+ * Plugin URI:      https://example.com/
+ * Description:     A plugin to interact with the Idealista scraper backend.
+ * Author:          Jules
+ * Author URI:      https://example.com/
+ * Text Domain:     idealista-scraper
+ * Domain Path:     /languages
+ * Version:         1.0.0
+ *
+ * @package         Idealista_Scraper
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+define( 'IDEALISTA_SCRAPER_VERSION', '1.0.0' );
+define( 'IDEALISTA_SCRAPER_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'IDEALISTA_SCRAPER_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+// Include the main plugin class.
+require_once IDEALISTA_SCRAPER_PLUGIN_DIR . 'includes/class-idealista-scraper.php';
+
+/**
+ * Begins execution of the plugin.
+ *
+ * Since everything within the plugin is registered via hooks,
+ * kicking off the plugin from this point in the file does
+ * not affect the page life cycle.
+ *
+ * @since    1.0.0
+ */
+function run_idealista_scraper() {
+
+    $plugin = new Idealista_Scraper();
+    $plugin->run();
+
+}
+run_idealista_scraper();


### PR DESCRIPTION
This commit introduces a complete, installable WordPress plugin that acts as a client for the existing Idealista scraper backend.

The plugin provides a user-friendly interface within the WordPress admin dashboard to:
- Configure the backend API URL.
- Start new scraping sessions.
- Monitor the status of ongoing and completed sessions.
- View scraped property data in a tabular format.
- Handle and solve CAPTCHAs when required by the backend.

The plugin follows WordPress best practices, including a standard file structure, use of the Settings and AJAX APIs, and security nonces.

A `build.sh` script is included to package the plugin into a distributable zip file, and a comprehensive `README.md` provides instructions for setting up both the backend and the plugin.