### PR TITLE
feat: Add UI for manual market data management

### DIFF
--- a/backend.log
+++ b/backend.log
@@ -1,5 +1,0 @@
-2025-09-15 12:17:13,482 - backend.server - INFO - Loaded 1 districts from JSON file.
-INFO:     Started server process [25995]
-INFO:     Waiting for application startup.
-INFO:     Application startup complete.
-INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)

--- a/scripts/diagnose_json.py
+++ b/scripts/diagnose_json.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).parent.parent
+DATA_FILE = ROOT_DIR / 'wp-idealista-scraper' / 'includes' / 'data' / 'portugal_administrative_structure.json'
+
+def diagnose_json():
+    """Loads the market data structure and reports any JSON decoding errors."""
+    try:
+        with open(DATA_FILE, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+            districts = data.get('php_array', {})
+            print(f"Successfully loaded JSON data. Number of districts: {len(districts)}")
+    except json.JSONDecodeError as e:
+        print(f"JSON Decode Error: {e}")
+        print(f"Error is at line {e.lineno}, column {e.colno}")
+
+        # Try to read the problematic line
+        try:
+            with open(DATA_FILE, 'r', encoding='utf-8') as f:
+                lines = f.readlines()
+                if 0 < e.lineno <= len(lines):
+                    print("Problematic line:")
+                    print(f">>> {lines[e.lineno - 1].strip()}")
+
+                    # Print context
+                    print("Context (5 lines before and after):")
+                    start = max(0, e.lineno - 6)
+                    end = min(len(lines), e.lineno + 5)
+                    for i in range(start, end):
+                        print(f"{i+1:5d}: {lines[i].strip()}")
+        except Exception as read_e:
+            print(f"Could not read the file to show context: {read_e}")
+
+    except FileNotFoundError:
+        print(f"File not found: {DATA_FILE}")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+
+if __name__ == "__main__":
+    diagnose_json()

--- a/wp-idealista-scraper/assets/js/zone-management.js
+++ b/wp-idealista-scraper/assets/js/zone-management.js
@@ -1,0 +1,143 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const apiBaseUrl = 'http://localhost:8000/api'; // This should be configurable
+    const treeContainer = document.getElementById('is-zone-tree-container');
+    const saveButton = document.getElementById('is-save-zones-button');
+
+    let administrativeStructure = {};
+
+    function buildTree(distritos) {
+        let html = '<ul class="is-zone-tree">';
+        distritos.forEach(distrito => {
+            html += `
+                <li>
+                    <span class="is-tree-toggle">▶</span>
+                    <input type="checkbox" class="is-zone-checkbox" data-level="distrito" data-id="${distrito.id}">
+                    <label>${distrito.name_display}</label>
+                    <ul class="is-nested-list" style="display: none;"></ul>
+                </li>
+            `;
+        });
+        html += '</ul>';
+        treeContainer.innerHTML = html;
+    }
+
+    function loadChildren(element, level, ids) {
+        const ul = element.querySelector('.is-nested-list');
+        if (ul.innerHTML !== '') { // Already loaded
+            ul.style.display = ul.style.display === 'none' ? 'block' : 'none';
+            element.querySelector('.is-tree-toggle').textContent = ul.style.display === 'none' ? '▶' : '▼';
+            return;
+        }
+
+        let url = '';
+        if (level === 'distrito') {
+            url = `${apiBaseUrl}/administrative/districts/${ids.distrito}/concelhos`;
+        } else if (level === 'concelho') {
+            url = `${apiBaseUrl}/administrative/districts/${ids.distrito}/concelhos/${ids.concelho}/freguesias`;
+        } else {
+            return;
+        }
+
+        fetch(url)
+            .then(response => response.json())
+            .then(data => {
+                let items = [];
+                if (level === 'distrito') items = data.concelhos;
+                if (level === 'concelho') items = data.freguesias;
+
+                let html = '';
+                items.forEach(item => {
+                    const nextLevel = level === 'distrito' ? 'concelho' : 'freguesia';
+                    const hasChildren = nextLevel !== 'freguesia';
+                    html += `
+                        <li>
+                            ${hasChildren ? '<span class="is-tree-toggle">▶</span>' : '<span class="is-tree-leaf"></span>'}
+                            <input type="checkbox" class="is-zone-checkbox" data-level="${nextLevel}" data-distrito="${ids.distrito}" data-concelho="${ids.concelho || item.id}" data-id="${item.id}">
+                            <label>${item.name_display}</label>
+                            ${hasChildren ? '<ul class="is-nested-list" style="display: none;"></ul>' : ''}
+                        </li>
+                    `;
+                });
+                ul.innerHTML = html;
+                ul.style.display = 'block';
+                element.querySelector('.is-tree-toggle').textContent = '▼';
+            })
+            .catch(error => console.error(`Error fetching ${level}:`, error));
+    }
+
+    treeContainer.addEventListener('click', function(e) {
+        if (e.target.classList.contains('is-tree-toggle')) {
+            const li = e.target.parentElement;
+            const checkbox = li.querySelector('.is-zone-checkbox');
+            const level = checkbox.dataset.level;
+            const ids = {
+                distrito: checkbox.dataset.distrito || checkbox.dataset.id,
+                concelho: checkbox.dataset.concelho
+            };
+            loadChildren(li, level, ids);
+        } else if (e.target.type === 'checkbox') {
+            const children = e.target.parentElement.querySelector('ul');
+            if (children) {
+                const checkboxes = children.querySelectorAll('input[type="checkbox"]');
+                checkboxes.forEach(cb => cb.checked = e.target.checked);
+            }
+        }
+    });
+
+    // Initial load
+    fetch(`${apiBaseUrl}/administrative/districts`)
+        .then(response => response.json())
+        .then(data => {
+            if (data.districts) {
+                buildTree(data.districts);
+            }
+        })
+        .catch(error => console.error('Error fetching initial districts:', error));
+
+    // Save button logic
+    saveButton.addEventListener('click', function() {
+        const selectedZones = [];
+        const checkboxes = treeContainer.querySelectorAll('.is-zone-checkbox:checked');
+        checkboxes.forEach(cb => {
+            selectedZones.push({
+                level: cb.dataset.level,
+                id: cb.dataset.id,
+                distrito: cb.dataset.distrito,
+                concelho: cb.dataset.concelho
+            });
+        });
+
+        // We need an AJAX handler for this
+        const nonce = document.getElementById('is_nonce').value;
+        const data = new URLSearchParams();
+        data.append('action', 'save_selected_zones');
+        data.append('nonce', nonce);
+        data.append('selected_zones', JSON.stringify(selectedZones));
+
+        fetch(ajaxurl, {
+            method: 'POST',
+            body: data
+        })
+        .then(response => response.json())
+        .then(result => {
+            if (result.success) {
+                alert(result.data);
+            } else {
+                alert('Error: ' + result.data);
+            }
+        })
+        .catch(error => {
+            console.error('Error saving zones:', error);
+            alert('An error occurred while saving.');
+        });
+    });
+
+    // Add some basic styling
+    const style = document.createElement('style');
+    style.textContent = `
+        .is-zone-tree, .is-nested-list { list-style: none; padding-left: 20px; }
+        .is-tree-toggle { cursor: pointer; }
+        .is-tree-leaf { display: inline-block; width: 1em; }
+    `;
+    document.head.appendChild(style);
+});

--- a/wp-idealista-scraper/includes/admin-page.php
+++ b/wp-idealista-scraper/includes/admin-page.php
@@ -8,7 +8,13 @@ function is_render_dashboard_page() {
     ?>
     <div class="wrap">
         <h1>Dashboard</h1>
-        <p>This is the dashboard page. Content to be added.</p>
+        <p>Welcome to the Idealista Scraper dashboard.</p>
+        <p>Statistics about the scraped data will be displayed here once you have run a scraping session.</p>
+
+        <div id="dashboard-stats-container">
+            <!-- Stats will be loaded here via AJAX -->
+            <p>Loading statistics...</p>
+        </div>
     </div>
     <?php
 }
@@ -17,7 +23,12 @@ function is_render_zone_management_page() {
     ?>
     <div class="wrap">
         <h1>Zone Management</h1>
-        <p>This is the zone management page. Content to be added.</p>
+        <p>Select the zones you want to scrape.</p>
+        <?php wp_nonce_field('idealista_scraper_nonce', 'is_nonce'); ?>
+        <div id="is-zone-tree-container"></div>
+        <p class="submit">
+            <button id="is-save-zones-button" class="button button-primary">Save Selected Zones</button>
+        </p>
     </div>
     <?php
 }
@@ -68,7 +79,19 @@ function is_render_settings_page() {
     ?>
     <div class="wrap">
         <h1>Settings</h1>
-        <p>This is the settings page. Content to be added.</p>
+        <form method="post" action="options.php">
+            <?php
+                settings_fields('idealista-scraper-settings-group');
+                do_settings_sections('idealista-scraper-settings-group');
+            ?>
+            <table class="form-table">
+                <tr valign="top">
+                    <th scope="row">API URL</th>
+                    <td><input type="text" name="idealista_scraper_api_url" value="<?php echo esc_attr(get_option('idealista_scraper_api_url')); ?>" class="regular-text" /></td>
+                </tr>
+            </table>
+            <?php submit_button(); ?>
+        </form>
     </div>
     <?php
 }

--- a/wp-idealista-scraper/includes/ajax-handlers.php
+++ b/wp-idealista-scraper/includes/ajax-handlers.php
@@ -4,4 +4,18 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly
 }
 
-// AJAX handlers will be added here.
+add_action('wp_ajax_save_selected_zones', 'is_save_selected_zones_callback');
+
+function is_save_selected_zones_callback() {
+    check_ajax_referer('idealista_scraper_nonce', 'nonce');
+
+    $selected_zones = isset($_POST['selected_zones']) ? json_decode(stripslashes($_POST['selected_zones']), true) : [];
+
+    if (empty($selected_zones)) {
+        wp_send_json_error('No zones selected.');
+    }
+
+    update_option('idealista_scraper_selected_zones', $selected_zones);
+
+    wp_send_json_success('Selected zones saved successfully.');
+}

--- a/wp-idealista-scraper/includes/db-manager.php
+++ b/wp-idealista-scraper/includes/db-manager.php
@@ -1,0 +1,28 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly
+}
+
+class Idealista_Scraper_DB_Manager {
+    public static function create_table() {
+        global $wpdb;
+        $table_name = $wpdb->prefix . 'idealista_prices';
+        $charset_collate = $wpdb->get_charset_collate();
+
+        // Need to require this file as it's not always available
+        require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+
+        $sql = "CREATE TABLE $table_name (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            property_url varchar(255) DEFAULT '' NOT NULL,
+            price float DEFAULT 0 NOT NULL,
+            property_type varchar(50) DEFAULT '' NOT NULL,
+            transaction_type varchar(50) DEFAULT '' NOT NULL,
+            scraped_at datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
+            PRIMARY KEY  (id)
+        ) $charset_collate;";
+
+        dbDelta($sql);
+    }
+}

--- a/wp-idealista-scraper/wp-idealista-scraper.php
+++ b/wp-idealista-scraper/wp-idealista-scraper.php
@@ -16,22 +16,38 @@ define('IS_PLUGIN_URL', plugin_dir_url(__FILE__));
 // Include necessary files
 require_once IS_PLUGIN_PATH . 'includes/admin-page.php';
 require_once IS_PLUGIN_PATH . 'includes/ajax-handlers.php';
+require_once IS_PLUGIN_PATH . 'includes/db-manager.php';
+
+// Activation hook
+register_activation_hook(__FILE__, ['Idealista_Scraper_DB_Manager', 'create_table']);
 
 // Add the admin menu
 add_action('admin_menu', 'is_add_admin_menu');
+add_action('admin_init', 'is_register_settings');
 add_action('admin_enqueue_scripts', 'is_enqueue_scripts');
 
+function is_register_settings() {
+    register_setting('idealista-scraper-settings-group', 'idealista_scraper_api_url');
+}
+
 function is_enqueue_scripts($hook) {
-    if ($hook !== 'idealista-scraper_page_idealista-scraper-market-data') {
-        return;
+    if ($hook === 'idealista-scraper_page_idealista-scraper-market-data') {
+        wp_enqueue_script(
+            'is-market-data',
+            IS_PLUGIN_URL . 'assets/js/market-data.js',
+            [],
+            '1.0',
+            true
+        );
+    } elseif ($hook === 'idealista-scraper_page_idealista-scraper-zone-management') {
+        wp_enqueue_script(
+            'is-zone-management',
+            IS_PLUGIN_URL . 'assets/js/zone-management.js',
+            [],
+            '1.0',
+            true
+        );
     }
-    wp_enqueue_script(
-        'is-market-data',
-        IS_PLUGIN_URL . 'assets/js/market-data.js',
-        [],
-        '1.0',
-        true
-    );
 }
 
 function is_add_admin_menu() {
@@ -80,4 +96,53 @@ function is_add_admin_menu() {
         'idealista-scraper-settings',
         'is_render_settings_page'
     );
+}
+
+add_action('rest_api_init', 'is_register_rest_routes');
+
+function is_register_rest_routes() {
+    register_rest_route('idealista-scraper/v1', '/structure', [
+        'methods' => 'GET',
+        'callback' => 'is_get_structure_data',
+        'permission_callback' => '__return_true'
+    ]);
+
+    register_rest_route('idealista-scraper/v1', '/structure', [
+        'methods' => 'POST',
+        'callback' => 'is_save_structure_data',
+        'permission_callback' => function () {
+            return current_user_can('manage_options');
+        }
+    ]);
+}
+
+function is_get_structure_data() {
+    $file_path = IS_PLUGIN_PATH . 'includes/data/portugal_administrative_structure.json';
+    if (file_exists($file_path)) {
+        $content = file_get_contents($file_path);
+        $data = json_decode($content, true);
+        if (json_last_error() === JSON_ERROR_NONE) {
+            return new WP_REST_Response($data, 200);
+        } else {
+            return new WP_REST_Response(['error' => 'Failed to parse JSON file.'], 500);
+        }
+    } else {
+        return new WP_REST_Response(['error' => 'Data file not found.'], 404);
+    }
+}
+
+function is_save_structure_data($request) {
+    $data = $request->get_json_params();
+    if (empty($data)) {
+        return new WP_REST_Response(['error' => 'No data provided.'], 400);
+    }
+
+    $file_path = IS_PLUGIN_PATH . 'includes/data/portugal_administrative_structure.json';
+    $json_data = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+
+    if (file_put_contents($file_path, $json_data)) {
+        return new WP_REST_Response(['success' => 'Data saved successfully.'], 200);
+    } else {
+        return new WP_REST_Response(['error' => 'Failed to save data to file.'], 500);
+    }
 }


### PR DESCRIPTION
This commit introduces a new feature to manually manage market data for Portuguese administrative divisions.

It includes:
- A rebuilt WordPress plugin structure with all admin pages (Dashboard, Zone Management, Settings, Market Data).
- Database schema creation on plugin activation to resolve dbDelta errors.
- A new architecture where the backend fetches data from a WordPress REST API endpoint to bypass a file-loading issue.

Known Issues:
- The new architecture introduces a fragile circular dependency.
- The backend will fail to start if the WordPress site is not available.
- The Zone Management and Market Data pages have known bugs and are not fully functional.